### PR TITLE
Claude: Real drone telemetry — live battery, wifi, altitude in HUD (#44)

### DIFF
--- a/backend/drone_protocol.py
+++ b/backend/drone_protocol.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Tuple
 
 # Protocol Constants
@@ -112,3 +113,38 @@ def build_handshake_packet() -> bytes:
 def build_video_init_packet() -> bytes:
     """Video init packet sent to PORT_VIDEO to start MJPEG stream."""
     return bytes([0xEF, 0x00, 0x04, 0x00])
+
+
+@dataclass
+class TelemetryPacket:
+    battery: int      # 0–100 %
+    wifi: int         # 0–100 %
+    altitude: float   # metres
+    flight_mode: int  # raw flags byte
+
+
+def parse_telemetry_packet(data: bytes) -> TelemetryPacket:
+    """
+    Parse an E58/Lewei ~10-byte UDP status packet from the X69 drone.
+
+    Known layout:
+      [0]  header byte
+      [1]  battery level  (0–100 raw)
+      [2]  wifi/link strength (0–100 raw)
+      [3]  flight mode flags
+      [4]  altitude high byte
+      [5]  altitude low byte  ((high<<8|low) / 10.0 metres)
+
+    Raises ValueError for packets shorter than 6 bytes.
+    """
+    if len(data) < 6:
+        raise ValueError(f"Telemetry packet too short: {len(data)} bytes")
+
+    battery  = max(0, min(100, data[1]))
+    wifi     = max(0, min(100, data[2])) if len(data) > 2 else 0
+    mode     = data[3] if len(data) > 3 else 0
+    alt_raw  = ((data[4] << 8) | data[5]) if len(data) > 5 else 0
+    altitude = round(alt_raw / 10.0, 1)
+
+    return TelemetryPacket(battery=battery, wifi=wifi,
+                           altitude=altitude, flight_mode=mode)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,38 +1,69 @@
 import asyncio
 import json
 import time
+from dataclasses import dataclass, asdict
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from contextlib import asynccontextmanager
 
 from .drone_connection import DroneConnection
 from .video_stream import VideoStream
+from .telemetry_receiver import TelemetryReceiver
 from .drone_protocol import (
     FLAG_EMERGENCY,
     FLAG_LAND,
     FLAG_NONE,
     FLAG_TAKEOFF,
     STICK_NEUTRAL,
+    TelemetryPacket,
 )
+
+
+@dataclass
+class TelemetryState:
+    battery: int = 0
+    wifi: int = 0
+    altitude: float = 0.0
+    flight_mode: int = 0
+
 
 # Shared drone instances
 drone = DroneConnection()
 video = VideoStream()
+telemetry = TelemetryReceiver()
+telemetry_state = TelemetryState()
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Startup: Connect to drone and start video listener
     await drone.connect()
     await video.start()
+
+    async def _on_telemetry(packet: TelemetryPacket) -> None:
+        telemetry_state.battery = packet.battery
+        telemetry_state.wifi = packet.wifi
+        telemetry_state.altitude = packet.altitude
+        telemetry_state.flight_mode = packet.flight_mode
+
+    telemetry.on_telemetry = _on_telemetry
+    await telemetry.start()
+
     yield
-    # Shutdown: Clean up resources
+
     await drone.disconnect()
     await video.stop()
+    await telemetry.stop()
 
 app = FastAPI(lifespan=lifespan)
+
 
 @app.get("/status")
 async def get_status():
     return {"status": "online", "drone_ip": drone.drone_ip}
+
+
+@app.get("/api/telemetry")
+async def get_telemetry():
+    return asdict(telemetry_state)
 
 
 @app.post("/api/connect")
@@ -94,6 +125,19 @@ async def websocket_control(websocket: WebSocket):
         print(f"Control WS Error: {e}")
     finally:
         monitor_task.cancel()
+
+@app.websocket("/ws/telemetry")
+async def websocket_telemetry(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            await asyncio.sleep(0.5)  # 2Hz push
+            await websocket.send_json(asdict(telemetry_state))
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        print(f"Telemetry WS Error: {e}")
+
 
 @app.websocket("/ws/video")
 async def websocket_video(websocket: WebSocket):

--- a/backend/telemetry_receiver.py
+++ b/backend/telemetry_receiver.py
@@ -1,0 +1,73 @@
+import asyncio
+import logging
+import socket
+from typing import Optional, Callable, Awaitable
+
+from .drone_protocol import TelemetryPacket, parse_telemetry_packet, PORT_HANDSHAKE
+
+logger = logging.getLogger(__name__)
+
+TelemetryCallback = Callable[[TelemetryPacket], Awaitable[None]]
+
+
+class TelemetryReceiver:
+    """
+    Listens for UDP status packets from the X69 drone on PORT_HANDSHAKE (40000).
+    The drone sends ~10-byte telemetry replies to the host that initiated the handshake.
+    """
+
+    def __init__(self, host: str = "0.0.0.0", port: int = PORT_HANDSHAKE):
+        self.host = host
+        self.port = port
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+        self._socket: Optional[socket.socket] = None
+        self.on_telemetry: Optional[TelemetryCallback] = None
+
+    async def start(self) -> None:
+        """Start the UDP listener task."""
+        if self._running:
+            return
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket.bind((self.host, self.port))
+        self._socket.setblocking(False)
+        self._running = True
+        self._task = asyncio.create_task(self._listen())
+
+    async def stop(self) -> None:
+        """Stop the listener and close the socket."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        if self._socket:
+            self._socket.close()
+            self._socket = None
+
+    async def _listen(self) -> None:
+        """UDP receive loop."""
+        loop = asyncio.get_event_loop()
+        while self._running:
+            try:
+                data, _ = await loop.sock_recvfrom(self._socket, 256)
+
+                # Skip handshake echo packets (start with 0x63) and too-short packets
+                if len(data) < 6 or data[0] == 0x63:
+                    continue
+
+                try:
+                    packet = parse_telemetry_packet(data)
+                    if self.on_telemetry:
+                        await self.on_telemetry(packet)
+                except ValueError as e:
+                    logger.debug("Ignoring unrecognised telemetry packet: %s", e)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warning("Telemetry receive error: %s", e)
+                await asyncio.sleep(0.1)

--- a/backend/test_telemetry.py
+++ b/backend/test_telemetry.py
@@ -1,0 +1,153 @@
+import asyncio
+import socket
+from unittest.mock import AsyncMock, patch, MagicMock
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from .drone_protocol import TelemetryPacket, parse_telemetry_packet
+from .telemetry_receiver import TelemetryReceiver
+
+
+# ---------------------------------------------------------------------------
+# parse_telemetry_packet tests
+# ---------------------------------------------------------------------------
+
+def test_parse_telemetry_valid_10byte_packet():
+    # battery=75, wifi=80, mode=0x02, altitude=(0x00<<8|0x3C)=60 → 6.0m
+    data = bytes([0x66, 75, 80, 0x02, 0x00, 0x3C, 0x00, 0x00, 0x00, 0x99])
+    pkt = parse_telemetry_packet(data)
+    assert pkt.battery == 75
+    assert pkt.wifi == 80
+    assert pkt.flight_mode == 0x02
+    assert pkt.altitude == 6.0
+
+
+def test_parse_telemetry_minimum_6byte_packet():
+    # 6 bytes: wifi field present but altitude partially present
+    data = bytes([0x66, 50, 60, 0x01, 0x00, 0x14])
+    pkt = parse_telemetry_packet(data)
+    assert pkt.battery == 50
+    assert pkt.wifi == 60
+    assert pkt.flight_mode == 0x01
+    assert pkt.altitude == 2.0  # (0x00<<8|0x14)=20 → 2.0m
+
+
+def test_parse_telemetry_rejects_too_short():
+    data = bytes([0x66, 50, 60, 0x01, 0x00])  # only 5 bytes
+    with pytest.raises(ValueError, match="too short"):
+        parse_telemetry_packet(data)
+
+
+def test_parse_telemetry_clamps_battery():
+    data = bytes([0x66, 255, 255, 0x00, 0x00, 0x00])
+    pkt = parse_telemetry_packet(data)
+    assert pkt.battery == 100
+    assert pkt.wifi == 100
+
+
+def test_parse_telemetry_altitude_encoding():
+    # alt high=0x00, low=0x3C → 60 raw → 6.0 metres
+    data = bytes([0x66, 0, 0, 0, 0x00, 0x3C])
+    pkt = parse_telemetry_packet(data)
+    assert pkt.altitude == 6.0
+
+
+def test_parse_telemetry_altitude_two_byte_range():
+    # high=0x01, low=0x00 → 256 → 25.6 metres
+    data = bytes([0x66, 0, 0, 0, 0x01, 0x00])
+    pkt = parse_telemetry_packet(data)
+    assert pkt.altitude == 25.6
+
+
+# ---------------------------------------------------------------------------
+# TelemetryReceiver tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_telemetry_receiver_ignores_handshake_echo():
+    """Packets starting with 0x63 (handshake echo) must be silently dropped."""
+    callback = AsyncMock()
+    receiver = TelemetryReceiver(port=40099)  # offset port avoids system conflicts
+
+    mock_sock = MagicMock()
+    handshake_echo = bytes([0x63, 0x63, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x99])
+    # Return handshake echo once, then raise CancelledError to stop the loop
+    mock_sock.recvfrom = AsyncMock(side_effect=[
+        (handshake_echo, ("192.168.0.1", 40000)),
+        asyncio.CancelledError(),
+    ])
+
+    with patch("backend.telemetry_receiver.socket.socket") as mock_socket_cls:
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.setsockopt = MagicMock()
+        mock_sock.bind = MagicMock()
+        mock_sock.setblocking = MagicMock()
+        mock_sock.close = MagicMock()
+
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.sock_recvfrom = mock_sock.recvfrom
+            receiver.on_telemetry = callback
+            await receiver.start()
+            # Allow the loop to process
+            await asyncio.sleep(0)
+            await receiver.stop()
+
+    callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_receiver_calls_callback_on_valid_packet():
+    """A valid telemetry packet should trigger the on_telemetry callback."""
+    received: list[TelemetryPacket] = []
+
+    async def capture(pkt: TelemetryPacket):
+        received.append(pkt)
+
+    receiver = TelemetryReceiver(port=40098)
+
+    valid_packet = bytes([0x66, 75, 80, 0x02, 0x00, 0x3C, 0x00, 0x00, 0x00, 0x99])
+
+    mock_sock = MagicMock()
+    mock_sock.recvfrom = AsyncMock(side_effect=[
+        (valid_packet, ("192.168.0.1", 40000)),
+        asyncio.CancelledError(),
+    ])
+
+    with patch("backend.telemetry_receiver.socket.socket") as mock_socket_cls:
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.setsockopt = MagicMock()
+        mock_sock.bind = MagicMock()
+        mock_sock.setblocking = MagicMock()
+        mock_sock.close = MagicMock()
+
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.sock_recvfrom = mock_sock.recvfrom
+            receiver.on_telemetry = capture
+            await receiver.start()
+            await asyncio.sleep(0)
+            await receiver.stop()
+
+    assert len(received) == 1
+    assert received[0].battery == 75
+    assert received[0].wifi == 80
+    assert received[0].altitude == 6.0
+
+
+# ---------------------------------------------------------------------------
+# API endpoint test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_api_telemetry_returns_defaults():
+    """GET /api/telemetry should return all four keys with zero defaults."""
+    from .main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/api/telemetry")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "battery" in data
+    assert "wifi" in data
+    assert "altitude" in data
+    assert "flight_mode" in data

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ const FLAG_EMERGENCY = 0x04;
 const FLAG_GYRO_CAL = 0x08;
 
 function App() {
-    const { controlState, sendControl } = useDrone();
+    const { controlState, sendControl, telemetry } = useDrone();
     const controls = useRef({ roll: 128, pitch: 128, throttle: 0, yaw: 128, flags: 0 });
 
     // 20Hz heartbeat — send current controls via context
@@ -112,7 +112,7 @@ function App() {
     return (
         <div className="app-container">
             <VideoFeed />
-            <HUD battery={84} wifi={92} status={statusLabel} altitude={1.2} />
+            <HUD battery={telemetry.battery} wifi={telemetry.wifi} status={statusLabel} altitude={telemetry.altitude} />
 
             <div className="ui-overlay">
                 <div className="side-panel left">

--- a/frontend/src/DroneContext.tsx
+++ b/frontend/src/DroneContext.tsx
@@ -3,9 +3,20 @@ import type { ReactNode } from 'react';
 
 type ConnectionState = 'disconnected' | 'connecting' | 'connected';
 
+interface TelemetryData {
+    battery: number;
+    wifi: number;
+    altitude: number;
+    flight_mode: number;
+}
+
+const DEFAULT_TELEMETRY: TelemetryData = { battery: 0, wifi: 0, altitude: 0, flight_mode: 0 };
+
 interface DroneContextValue {
     controlState: ConnectionState;
     videoState: ConnectionState;
+    telemetryState: ConnectionState;
+    telemetry: TelemetryData;
     sendControl: (data: Record<string, number>) => void;
     onVideoFrame: (handler: (data: Blob) => void) => () => void;
 }
@@ -62,6 +73,8 @@ function createReconnectingWs(
 export function DroneProvider({ children }: { children: ReactNode }) {
     const [controlState, setControlState] = useState<ConnectionState>('disconnected');
     const [videoState, setVideoState] = useState<ConnectionState>('disconnected');
+    const [telemetryState, setTelemetryState] = useState<ConnectionState>('disconnected');
+    const [telemetry, setTelemetry] = useState<TelemetryData>(DEFAULT_TELEMETRY);
     const controlWsRef = useRef<{ getWs: () => WebSocket | null; cleanup: () => void } | null>(null);
     const videoHandlerRef = useRef<((data: Blob) => void) | null>(null);
 
@@ -90,9 +103,25 @@ export function DroneProvider({ children }: { children: ReactNode }) {
             'blob',
         );
 
+        setTelemetryState('connecting');
+        const telemetryConn = createReconnectingWs(
+            `${base}/ws/telemetry`,
+            () => setTelemetryState('connected'),
+            () => setTelemetryState('disconnected'),
+            (e) => {
+                try {
+                    const data = JSON.parse(e.data as string) as TelemetryData;
+                    setTelemetry(data);
+                } catch {
+                    // malformed payload — ignore
+                }
+            },
+        );
+
         return () => {
             controlWsRef.current?.cleanup();
             videoConn.cleanup();
+            telemetryConn.cleanup();
         };
     }, []);
 
@@ -111,7 +140,7 @@ export function DroneProvider({ children }: { children: ReactNode }) {
     };
 
     return (
-        <DroneContext.Provider value={{ controlState, videoState, sendControl, onVideoFrame }}>
+        <DroneContext.Provider value={{ controlState, videoState, telemetryState, telemetry, sendControl, onVideoFrame }}>
             {children}
         </DroneContext.Provider>
     );


### PR DESCRIPTION
## Summary

Replaces hardcoded HUD values with live drone telemetry data from UDP status packets.

- **`backend/drone_protocol.py`** — adds `TelemetryPacket` dataclass and `parse_telemetry_packet()` for E58/Lewei ~10-byte UDP status packets (battery, wifi, altitude, flight_mode)
- **`backend/telemetry_receiver.py`** (new) — `TelemetryReceiver` class mirroring `VideoStream`; binds UDP `0.0.0.0:40000`, filters handshake echo packets, calls `on_telemetry` callback
- **`backend/main.py`** — wires `TelemetryReceiver` into lifespan, adds `/api/telemetry` REST endpoint and `/ws/telemetry` WebSocket (2Hz push)
- **`frontend/src/DroneContext.tsx`** — extends context with `telemetryState` + `telemetry` via third `createReconnectingWs` connection; defaults to zeros before first packet arrives
- **`frontend/src/App.tsx`** — replaces `battery={84} wifi={92} altitude={1.2}` with live `telemetry.*` values
- **`backend/test_telemetry.py`** (new) — 9 tests covering packet parsing, clamping, edge cases, receiver filtering, and `/api/telemetry` endpoint

## Test plan

- [x] All 37 backend tests pass (`python -m pytest backend/ -v`)
- [ ] Start backend: `uvicorn backend.main:app --reload` → `GET /api/telemetry` returns `{"battery":0,"wifi":0,"altitude":0.0,"flight_mode":0}`
- [ ] Connect to X69 WiFi → HUD updates with live battery, wifi, altitude
- [ ] Without drone: HUD shows zeros (graceful degradation)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)